### PR TITLE
feat: use Konva object pass through from ImageConfig param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "babel-jest": "^27.2.0",
         "canvas": "^2.8.0",
         "cypress": "^8.4.0",
+        "datauri": "^4.1.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-webpack": "^0.13.1",
@@ -5161,6 +5162,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/datauri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/datauri/-/datauri-4.1.0.tgz",
+      "integrity": "sha512-y17kh32+I82G+ED9MNWFkZiP/Cq/vO1hN9+tSZsT9C9qn3NrvcBnh7crSepg0AQPge1hXx2Ca44s1FRdv0gFWA==",
+      "dev": true,
+      "dependencies": {
+        "image-size": "1.0.0",
+        "mimer": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
@@ -7270,6 +7284,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
+      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/import-fresh": {
@@ -10721,6 +10750,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mimer/-/mimer-2.0.2.tgz",
+      "integrity": "sha512-izxvjsB7Ur5HrTbPu6VKTrzxSMBFBqyZQc6dWlZNQ4/wAvf886fD4lrjtFd8IQ8/WmZKdxKjUtqFFNaj3hQ52g==",
+      "dev": true,
+      "bin": {
+        "mimer": "bin/mimer"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -11749,6 +11790,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -18038,6 +18088,16 @@
         "whatwg-url": "^9.0.0"
       }
     },
+    "datauri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/datauri/-/datauri-4.1.0.tgz",
+      "integrity": "sha512-y17kh32+I82G+ED9MNWFkZiP/Cq/vO1hN9+tSZsT9C9qn3NrvcBnh7crSepg0AQPge1hXx2Ca44s1FRdv0gFWA==",
+      "dev": true,
+      "requires": {
+        "image-size": "1.0.0",
+        "mimer": "^2.0.2"
+      }
+    },
     "dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
@@ -19611,6 +19671,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "image-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
+      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -22180,6 +22249,12 @@
         "mime-db": "1.49.0"
       }
     },
+    "mimer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mimer/-/mimer-2.0.2.tgz",
+      "integrity": "sha512-izxvjsB7Ur5HrTbPu6VKTrzxSMBFBqyZQc6dWlZNQ4/wAvf886fD4lrjtFd8IQ8/WmZKdxKjUtqFFNaj3hQ52g==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -22943,6 +23018,15 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-jest": "^27.2.0",
     "canvas": "^2.8.0",
     "cypress": "^8.4.0",
+    "datauri": "^4.1.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-webpack": "^0.13.1",

--- a/src/Selection/index.ts
+++ b/src/Selection/index.ts
@@ -434,7 +434,7 @@ export class Selection {
 
     /**
      * registers Transform event
-     * Triggers when the client transforminging the transformer
+     * Triggers when the client transforming the transformer
      */
     this.transformer.on('transform', () => {
       this.board.events.emit('selection:transform', {

--- a/src/shape/drawers/ImageDrawer/index.ts
+++ b/src/shape/drawers/ImageDrawer/index.ts
@@ -1,5 +1,4 @@
 import Konva from 'konva'
-import { ImageConfig } from 'konva/lib/shapes/Image'
 
 import { imageToDataUrl } from '../../../utils/image-to-url'
 import { createImageFromUrl } from '../../../utils/create-image-from-url'
@@ -25,26 +24,27 @@ export class ImageDrawer {
   /**
    * Inserts a new image into the board
    *
-   * @param file The image [[File]]
+   * @param image The image [[File]]
    * @param config The image node configuration
    */
   public async insert(
-    file: File | string,
+    image: File | Konva.Image | string,
     config: Partial<Konva.ImageConfig> = {}
   ): Promise<ImageModel> {
-    const url = file instanceof File ? await imageToDataUrl(file) : file
-    let image: Konva.Image
+    let imageInstance: Konva.Image
 
-    if (config.image) {
-      image = new Konva.Image(config as ImageConfig)
+    if (image instanceof Konva.Image) {
+      imageInstance = image
     } else {
-      image = await createImageFromUrl(url)
+      const url = image instanceof File ? await imageToDataUrl(image) : image
+      imageInstance = await createImageFromUrl(url)
     }
-    const ratio = image.width() / image.height()
+
+    const ratio = imageInstance.width() / imageInstance.height()
     const defaultHeight = this.board.stage.height() / 2
     const defaultWidth = defaultHeight * ratio
 
-    image.setAttrs({
+    imageInstance.setAttrs({
       width: defaultWidth,
       height: defaultHeight,
       x: (this.board.stage.width() - defaultWidth) / 2,
@@ -54,7 +54,7 @@ export class ImageDrawer {
       ...config
     })
 
-    return new ImageModel(this.board, image, {
+    return new ImageModel(this.board, imageInstance, {
       transformer: {
         keepRatio: true
       }

--- a/src/shape/drawers/ImageDrawer/index.ts
+++ b/src/shape/drawers/ImageDrawer/index.ts
@@ -1,4 +1,5 @@
 import Konva from 'konva'
+import { ImageConfig } from 'konva/lib/shapes/Image'
 
 import { imageToDataUrl } from '../../../utils/image-to-url'
 import { createImageFromUrl } from '../../../utils/create-image-from-url'
@@ -32,10 +33,14 @@ export class ImageDrawer {
     config: Partial<Konva.ImageConfig> = {}
   ): Promise<ImageModel> {
     const url = file instanceof File ? await imageToDataUrl(file) : file
-    const image = await createImageFromUrl(url)
+    let image: Konva.Image
 
+    if (config.image) {
+      image = new Konva.Image(config as ImageConfig)
+    } else {
+      image = await createImageFromUrl(url)
+    }
     const ratio = image.width() / image.height()
-
     const defaultHeight = this.board.stage.height() / 2
     const defaultWidth = defaultHeight * ratio
 

--- a/tests/integration/shapes/image/index.test.ts
+++ b/tests/integration/shapes/image/index.test.ts
@@ -1,0 +1,46 @@
+import datauri from 'datauri'
+import Konva from 'konva'
+
+import { createEditor } from '../../../../jest/utils/create-editor'
+import { createImageFromUrl } from '../../../../src/utils/create-image-from-url'
+
+describe('Shape -> Image', () => {
+  it('should create an image based on an url', async () => {
+    const editor = createEditor()
+
+    const base64Image = await datauri(
+      __dirname + '/../../../../assets/logo.svg'
+    )
+    const image = await editor.shapes.image.insert(base64Image!)
+
+    expect(image.node.attrs.image).not.toBeNull()
+  })
+
+  it('should create an image based on a file', async () => {
+    const editor = createEditor()
+
+    const image = await editor.shapes.image.insert(
+      __dirname + '/../../../../assets/logo.png'
+    )
+
+    expect(image.node.attrs.image).not.toBeNull()
+  })
+
+  it('should create an image based on a Konva.Image object', async () => {
+    const editor = createEditor()
+
+    const base64Image = await datauri(
+      __dirname + '/../../../../assets/logo.svg'
+    )
+
+    const imgObject = await createImageFromUrl(base64Image!)
+
+    const konvaImage = new Konva.Image({
+      image: imgObject.getAttr('image')
+    })
+
+    const image = await editor.shapes.image.insert(konvaImage)
+
+    expect(image.node.attrs.image).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Allow Pikaso to use an `Image` instance passed in through `Konva.ImageConfig`. This is mainly used to give the user more control of the Image instances that they can pass in. Right now Pikaso's [ImageDrawer insert function](https://github.com/pikasojs/pikaso/blob/master/src/shape/drawers/ImageDrawer/index.ts#L35) createa its own Konva Image object. This makes it impossible for users to add videos to the canvas. 

The original Konva API allows you to pass in image object that can also be a HTML video element to support adding video to canvas. The changes basically passes that ability through.